### PR TITLE
context fields misplaced wrt other fixtures

### DIFF
--- a/v1p1/caliperEntitySearchResponse.json
+++ b/v1p1/caliperEntitySearchResponse.json
@@ -1,4 +1,5 @@
 {
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SearchProfile-extension",
   "id": "https://example.edu/users/554433/search?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29",
   "type": "SearchResponse",
   "searchProvider": {
@@ -10,7 +11,6 @@
     "type": "SoftwareApplication"
   },
   "query": {
-    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SearchProfile-extension",
     "id": "https://example.edu/users/554433/search?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29",
     "type": "Query",
     "creator": {

--- a/v1p1/caliperEventSearchSearched.json
+++ b/v1p1/caliperEventSearchSearched.json
@@ -18,7 +18,6 @@
     "searchProvider": "https://example.edu",
     "searchTarget": "https://example.edu/catalog",
     "query": {
-      "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/SearchProfile-extension",
       "id": "https://example.edu/users/554433/search?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29",
       "type": "Query",
       "creator": "https://example.edu/users/554433",


### PR DESCRIPTION
For the Tool Launch profile we decided on a format for the fixtures that placed a single `@context` corresponding to the extended profile context doc at the root; we should use the same approach here.