### PR TITLE
Tool Launch Returned: updated fixtures and new Link and LtiLink entities

### DIFF
--- a/v1p1/caliperEntityLink.json
+++ b/v1p1/caliperEntityLink.json
@@ -1,0 +1,5 @@
+{
+    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/ToolLaunchProfile-extension",
+    "id": "https://example.edu/terms/201801/courses/7/sections/1/pages/1",
+    "type": "Link"
+}

--- a/v1p1/caliperEntityLtiLink.json
+++ b/v1p1/caliperEntityLtiLink.json
@@ -1,0 +1,6 @@
+{
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/ToolLaunchProfile-extension",
+  "id": "https://tool.com/link/123",
+  "type": "LtiLink",
+  "messageType": "LtiResourceLinkRequest"
+}

--- a/v1p1/caliperEntityLtiSession.json
+++ b/v1p1/caliperEntityLtiSession.json
@@ -1,28 +1,76 @@
 {
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/ToolLaunchProfile-extension",
   "id": "https://example.edu/lti/sessions/b533eb02823f31024e6b7f53436c42fb99b31241",
   "type": "LtiSession",
-  "user": {
-    "id": "https://example.edu/users/554433",
-    "type": "Person"
-  },
-  "messageParameters": {
-    "lti_message_type": "basic-lti-launch-request",
-    "lti_version": "LTI-1p0",
-    "context_id": "https://example.edu/terms/201801/courses/7/sections/1",
-    "context_type": "urn:lti:context-type:ims/lis/CourseSection",
-    "context_label": "CPS 435-01",
-    "context_title": "CPS 435 Learning Analytics, Section 01",
-    "resource_link_id": "6b37a950-42c9-4117-8f4f-03e6e5c88d24",
-    "roles": [ "urn:lti:role:ims/lis/Learner" ],
-    "tool_consumer_instance_guid": "SomeLMS.example.edu",
-    "tool_consumer_instance_description": "Sample University (SomeLMS)",
-    "user_id": "0ae836b9-7fc9-4060-006f-27b2066ac545",
-    "custom_xstart": "2016-08-21T01:00:00Z",
-    "custom_caliper_profile_url": "https://example.edu/lti/tc/cps",
-    "custom_caliper_session_id": "1c519ff7-3dfa-4764-be48-d2fb35a2925a",
-    "ext_com_somelms_example_course_section_instructor": "https://example.edu/faculty/1234"
+    "user": {
+      "id": "https://example.edu/users/554433",
+      "type": "Person"
   },
   "dateCreated": "2018-11-15T10:15:00.000Z",
-  "startedAtTime": "2018-11-15T10:15:00.000Z"
+  "startedAtTime": "2018-11-15T10:15:00.000Z",
+  "messageParameters": {
+     "iss": "https://example.edu",
+     "sub": "https://example.edu/users/554433",
+     "aud": ["https://example.com/lti/tool"],
+     "exp": 1510185728,
+     "iat": 1510185228,
+     "azp": "962fa4d8-bcbf-49a0-94b2-2de05ad274af",
+     "nonce": "fc5fdc6d-5dd6-47f4-b2c9-5d1216e9b771",
+     "name": "Ms Jane Marie Doe",
+     "given_name": "Jane",
+     "family_name": "Doe",
+     "middle_name": "Marie",
+     "picture": "https://example.edu/jane.jpg",
+     "email": "jane@example.edu",
+     "locale": "en-US",
+     "https://purl.imsglobal.org/spec/lti/claim/deployment_id": "07940580-b309-415e-a37c-914d387c1150",
+     "https://purl.imsglobal.org/spec/lti/claim/message_type": "LtiResourceLinkRequest",
+     "https://purl.imsglobal.org/spec/lti/claim/version": "1.3.0",
+     "https://purl.imsglobal.org/spec/lti/claim/roles": [
+        "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student",
+        "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner",
+        "http://purl.imsglobal.org/vocab/lis/v2/membership#Mentor"
+     ],
+     "https://purl.imsglobal.org/spec/lti/claim/role_scope_mentor": [
+        "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator"
+     ],
+     "https://purl.imsglobal.org/spec/lti/claim/context": {
+        "id": "https://example.edu/terms/201801/courses/7/sections/1",
+        "label": "CPS 435-01",
+        "title": "CPS 435 Learning Analytics, Section 01",
+        "type": ["http://purl.imsglobal.org/vocab/lis/v2/course#CourseSection"]
+     },
+     "https://purl.imsglobal.org/spec/lti/claim/resource_link": {
+        "id": "200d101f-2c14-434a-a0f3-57c2a42369fd",
+        "description": "Assignment to introduce who you are",
+        "title": "Introduction Assignment"
+     },
+     "https://purl.imsglobal.org/spec/lti/claim/tool_platform": {
+        "guid": "https://example.edu",
+        "contact_email": "support@example.edu",
+        "description": "An Example Tool Platform",
+        "name": "Example Tool Platform",
+        "url": "https://example.edu",
+        "product_family_code": "ExamplePlatformVendor-Product",
+        "version": "1.0"
+     },
+     "https://purl.imsglobal.org/spec/lti/claim/launch_presentation": {
+        "document_target": "iframe",
+        "height": 320,
+        "width": 240,
+        "return_url": "https://example.edu/terms/201801/courses/7/sections/1/pages/1"
+     },
+     "https://purl.imsglobal.org/spec/lti/claim/custom": {
+        "xstart": "2017-04-21T01:00:00Z",
+        "request_url": "https://tool.com/link/123"
+     },
+     "https://purl.imsglobal.org/spec/lti/claim/lis": {
+        "person_sourcedid": "example.edu:71ee7e42-f6d2-414a-80db-b69ac2defd4",
+        "course_offering_sourcedid": "example.edu:SI182-F16",
+        "course_section_sourcedid": "example.edu:SI182-001-F16"
+     },
+     "http://www.ExamplePlatformVendor.com/session": {
+        "id": "89023sj890dju080"
+     }
+  }
 }

--- a/v1p1/caliperEventToolLaunchLaunched.json
+++ b/v1p1/caliperEventToolLaunchLaunched.json
@@ -40,6 +40,11 @@
     "type": "Session",
     "startedAtTime": "2018-11-15T10:00:00.000Z"
   },
+  "target": {
+    "id": "https://tool.com/link/123",
+    "type": "LtiLink",
+    "messageType": "LtiResourceLinkRequest"
+  },
   "federatedSession": {
     "id": "https://example.edu/lti/sessions/b533eb02823f31024e6b7f53436c42fb99b31241",
     "type": "LtiSession",
@@ -47,24 +52,72 @@
       "id": "https://example.edu/users/554433",
       "type": "Person"
     },
-    "messageParameters": {
-      "lti_message_type": "basic-lti-launch-request",
-      "lti_version": "LTI-1p0",
-      "context_id": "https://example.edu/terms/201801/courses/7/sections/1",
-      "context_type": "urn:lti:context-type:ims/lis/CourseSection",
-      "context_label": "CPS 435-01",
-      "context_title": "CPS 435 Learning Analytics, Section 01",
-      "resource_link_id": "6b37a950-42c9-4117-8f4f-03e6e5c88d24",
-      "roles": [ "urn:lti:role:ims/lis/Learner" ],
-      "tool_consumer_instance_guid": "SomeLMS.example.edu",
-      "tool_consumer_instance_description": "Sample University (SomeLMS)",
-      "user_id": "0ae836b9-7fc9-4060-006f-27b2066ac545",
-      "custom_xstart": "2016-08-21T01:00:00Z",
-      "custom_caliper_profile_url": "https://example.edu/lti/tc/cps",
-      "custom_caliper_session_id": "1c519ff7-3dfa-4764-be48-d2fb35a2925a",
-      "ext_com_somelms_example_course_section_instructor": "https://example.edu/faculty/1234"
-    },
     "dateCreated": "2018-11-15T10:15:00.000Z",
-    "startedAtTime": "2018-11-15T10:15:00.000Z"
+    "startedAtTime": "2018-11-15T10:15:00.000Z",
+    "messageParameters": {
+       "iss": "https://example.edu",
+       "sub": "https://example.edu/users/554433",
+       "aud": ["https://example.com/lti/tool"],
+       "exp": 1510185728,
+       "iat": 1510185228,
+       "azp": "962fa4d8-bcbf-49a0-94b2-2de05ad274af",
+       "nonce": "fc5fdc6d-5dd6-47f4-b2c9-5d1216e9b771",
+       "name": "Ms Jane Marie Doe",
+       "given_name": "Jane",
+       "family_name": "Doe",
+       "middle_name": "Marie",
+       "picture": "https://example.edu/jane.jpg",
+       "email": "jane@example.edu",
+       "locale": "en-US",
+       "https://purl.imsglobal.org/spec/lti/claim/deployment_id": "07940580-b309-415e-a37c-914d387c1150",
+       "https://purl.imsglobal.org/spec/lti/claim/message_type": "LtiResourceLinkRequest",
+       "https://purl.imsglobal.org/spec/lti/claim/version": "1.3.0",
+       "https://purl.imsglobal.org/spec/lti/claim/roles": [
+          "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student",
+          "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner",
+          "http://purl.imsglobal.org/vocab/lis/v2/membership#Mentor"
+       ],
+       "https://purl.imsglobal.org/spec/lti/claim/role_scope_mentor": [
+          "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator"
+       ],
+       "https://purl.imsglobal.org/spec/lti/claim/context": {
+          "id": "https://example.edu/terms/201801/courses/7/sections/1",
+          "label": "CPS 435-01",
+          "title": "CPS 435 Learning Analytics, Section 01",
+          "type": ["http://purl.imsglobal.org/vocab/lis/v2/course#CourseSection"]
+       },
+       "https://purl.imsglobal.org/spec/lti/claim/resource_link": {
+          "id": "200d101f-2c14-434a-a0f3-57c2a42369fd",
+          "description": "Assignment to introduce who you are",
+          "title": "Introduction Assignment"
+       },
+       "https://purl.imsglobal.org/spec/lti/claim/tool_platform": {
+          "guid": "https://example.edu",
+          "contact_email": "support@example.edu",
+          "description": "An Example Tool Platform",
+          "name": "Example Tool Platform",
+          "url": "https://example.edu",
+          "product_family_code": "ExamplePlatformVendor-Product",
+          "version": "1.0"
+       },
+       "https://purl.imsglobal.org/spec/lti/claim/launch_presentation": {
+          "document_target": "iframe",
+          "height": 320,
+          "width": 240,
+          "return_url": "https://example.edu/terms/201801/courses/7/sections/1/pages/1"
+       },
+       "https://purl.imsglobal.org/spec/lti/claim/custom": {
+          "xstart": "2017-04-21T01:00:00Z",
+          "request_url": "https://tool.com/link/123"
+       },
+       "https://purl.imsglobal.org/spec/lti/claim/lis": {
+          "person_sourcedid": "example.edu:71ee7e42-f6d2-414a-80db-b69ac2defd4",
+          "course_offering_sourcedid": "example.edu:SI182-F16",
+          "course_section_sourcedid": "example.edu:SI182-001-F16"
+       },
+       "http://www.ExamplePlatformVendor.com/session": {
+          "id": "89023sj890dju080"
+       }
+    }
   }
 }

--- a/v1p1/caliperEventToolLaunchReturned.json
+++ b/v1p1/caliperEventToolLaunchReturned.json
@@ -1,0 +1,57 @@
+{
+    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/ToolLaunchProfile-extension",
+    "id": "urn:uuid:a2e8b214-4d4a-4456-bb4c-099945749117",
+    "type": "ToolLaunchEvent",
+    "actor": {
+      "id": "https://example.edu/users/554433",
+      "type": "Person"
+    },
+    "action": "Returned",
+    "object": {   
+      "id": "https://example.com/lti/tool",
+      "type": "SoftwareApplication"
+    },
+    "eventTime": "2018-11-15T10:15:00.000Z",
+    "edApp": {   
+      "id": "https://example.edu",
+      "type": "SoftwareApplication"    
+    },
+    "referrer": {   
+      "id": "https://tool.com/lti/123",
+      "type": "LtiLink"
+    },
+    "group": {   
+      "id": "https://example.edu/terms/201801/courses/7/sections/1",
+      "type": "CourseSection",
+      "courseNumber": "CPS 435-01",
+      "academicSession": "Fall 2018"
+    },
+    "membership": {   
+      "id": "https://example.edu/terms/201801/courses/7/sections/1/rosters/1",
+      "type": "Membership",
+      "member": "https://example.edu/users/554433",
+      "organization": "https://example.edu/terms/201801/courses/7/sections/1",
+      "roles": [ "Learner" ],
+      "status": "Active",
+      "dateCreated": "2018-08-01T06:00:00.000Z"
+    },
+    "session": {   
+      "id": "https://example.edu/sessions/1f6442a482de72ea6ad134943812bff564a76259",
+      "type": "Session",
+      "startedAtTime": "2018-11-15T10:00:00.000Z"
+    },
+    "target": {
+      "id": "https://example.edu/terms/201801/courses/7/sections/1/pages/1",
+      "type": "Link"
+    },
+    "federatedSession": {   
+      "id": "https://example.edu/lti/sessions/b533eb02823f31024e6b7f53436c42fb99b31241",
+      "type": "LtiSession",
+      "user": {
+        "id": "https://example.edu/users/554433",
+        "type": "Person"
+      },
+      "dateCreated": "2018-11-15T10:15:00.000Z",
+      "startedAtTime": "2018-11-15T10:15:00.000Z"
+    }
+}


### PR DESCRIPTION
This PR adds support for the current agreed-upon state of the Tool Launch Profile:

- Tool Launch Launched and Returned event fixtures that take their contents from the examples in the TL Profile PR into the spec

- LtiLink, Link entities (that, again, take their contents from the examples in the TL Profile PR into the spec)