### PR TITLE
caliperEntityLtiSession.json fixture: change @context value back to v1p1 context.

### DIFF
--- a/v1p1/caliperEntityLtiSession.json
+++ b/v1p1/caliperEntityLtiSession.json
@@ -1,5 +1,5 @@
 {
-  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/ToolLaunchProfile-extension",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1",
   "id": "https://example.edu/lti/sessions/b533eb02823f31024e6b7f53436c42fb99b31241",
   "type": "LtiSession",
     "user": {


### PR DESCRIPTION
Resolves #201.