### PR TITLE
Change 2016 date references to 2018

### DIFF
--- a/v1p1/caliperEventResourceManagementCopied.json
+++ b/v1p1/caliperEventResourceManagementCopied.json
@@ -1,6 +1,6 @@
 {
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1/ResourceManagementProfile-extension",
-  "id": "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369",
+  "id": "urn:uuid:d3543a73-e307-4190-a755-5ce7b3187bc5",
   "type": "ResourceManagementEvent",
   "actor": {
     "id": "https://example.edu/users/554433",

--- a/v1p1/caliperEventResourceManagementCopied.json
+++ b/v1p1/caliperEventResourceManagementCopied.json
@@ -30,7 +30,7 @@
     "dateCreated": "2018-08-02T11:32:00.000Z"
   },
   "generated": {
-    "id": "https://example.edu/terms/201801/courses/7/sections/1/resources/2/syllabus_copy.pdf",
+    "id": "https://example.edu/terms/201801/courses/7/sections/1/resources/1/syllabus_copy.pdf",
     "type": "DigitalResource",
     "name": "Course Syllabus (copy)",
     "mediaType": "application/pdf",

--- a/v1p1/caliperEventResourceManagementCopied.json
+++ b/v1p1/caliperEventResourceManagementCopied.json
@@ -54,16 +54,16 @@
   "eventTime": "2018-11-15T10:05:00.000Z",
   "edApp": "https://example.edu",
   "group": {
-    "id": "https://example.edu/terms/201601/courses/7/sections/1",
+    "id": "https://example.edu/terms/201801/courses/7/sections/1",
     "type": "CourseSection",
     "courseNumber": "CPS 435-01",
     "academicSession": "Fall 2018"
   },
   "membership": {
-    "id": "https://example.edu/terms/201601/courses/7/sections/1/rosters/1",
+    "id": "https://example.edu/terms/201801/courses/7/sections/1/rosters/1",
     "type": "Membership",
     "member": "https://example.edu/users/554433",
-    "organization": "https://example.edu/terms/201601/courses/7/sections/1",
+    "organization": "https://example.edu/terms/201801/courses/7/sections/1",
     "roles": [ "Instructor" ],
     "status": "Active",
     "dateCreated": "2018-08-01T06:00:00.000Z"

--- a/v1p1/caliperEventResourceManagementCreated.json
+++ b/v1p1/caliperEventResourceManagementCreated.json
@@ -32,16 +32,16 @@
   "eventTime": "2018-11-15T10:05:00.000Z",
   "edApp": "https://example.edu",
   "group": {
-    "id": "https://example.edu/terms/201601/courses/7/sections/1",
+    "id": "https://example.edu/terms/201801/courses/7/sections/1",
     "type": "CourseSection",
     "courseNumber": "CPS 435-01",
     "academicSession": "Fall 2018"
   },
   "membership": {
-    "id": "https://example.edu/terms/201601/courses/7/sections/1/rosters/1",
+    "id": "https://example.edu/terms/201801/courses/7/sections/1/rosters/1",
     "type": "Membership",
     "member": "https://example.edu/users/554433",
-    "organization": "https://example.edu/terms/201601/courses/7/sections/1",
+    "organization": "https://example.edu/terms/201801/courses/7/sections/1",
     "roles": [ "Instructor" ],
     "status": "Active",
     "dateCreated": "2018-08-01T06:00:00.000Z"


### PR DESCRIPTION
Resolves #207.  PR also changes the `ResourceManagementEvent` id for the `Copied` action so that the two test events feature different UUID values.