### PR TITLE
True up v1p2 fixtures with the current state of v1p1 fixtures

### DIFF
--- a/v1p2/caliperEntityAgent.json
+++ b/v1p2/caliperEntityAgent.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/agents/99999",
   "type": "Agent",
   "dateCreated": "2016-08-01T06:00:00.000Z",

--- a/v1p2/caliperEntityAnnotation.json
+++ b/v1p2/caliperEntityAnnotation.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.com/users/554433/texts/imscaliperimplguide/annotations/1",
   "type": "Annotation",
   "annotator": {

--- a/v1p2/caliperEntityAssessment.json
+++ b/v1p2/caliperEntityAssessment.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/terms/201601/courses/7/sections/1/assess/1",
   "type": "Assessment",
   "name": "Quiz One",

--- a/v1p2/caliperEntityAssessmentItemExtended.json
+++ b/v1p2/caliperEntityAssessmentItemExtended.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/terms/201601/courses/7/sections/1/assess/1/items/3",
   "type": "AssessmentItem",
   "isPartOf": {

--- a/v1p2/caliperEntityAssignableDigitalResource.json
+++ b/v1p2/caliperEntityAssignableDigitalResource.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/terms/201601/courses/7/sections/1/assign/2",
   "type": "AssignableDigitalResource",
   "name": "Week 9 Reflection",

--- a/v1p2/caliperEntityAttempt.json
+++ b/v1p2/caliperEntityAttempt.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/terms/201601/courses/7/sections/1/assess/1/users/554433/attempts/1",
   "type": "Attempt",
   "assignable": {

--- a/v1p2/caliperEntityAudioObject.json
+++ b/v1p2/caliperEntityAudioObject.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/audio/765",
   "type": "AudioObject",
   "name": "Audio Recording: IMS Caliper Sensor API Q&A.",

--- a/v1p2/caliperEntityBookmarkAnnotation.json
+++ b/v1p2/caliperEntityBookmarkAnnotation.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.com/users/554433/texts/imscaliperimplguide/bookmarks/1",
   "type": "BookmarkAnnotation",
   "annotator": {

--- a/v1p2/caliperEntityChapter.json
+++ b/v1p2/caliperEntityChapter.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.com/#/texts/imscaliperimplguide/cfi/6/10",
   "type": "Chapter",
   "name": "The Caliper Information Model",

--- a/v1p2/caliperEntityCourseOffering.json
+++ b/v1p2/caliperEntityCourseOffering.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/terms/201601/courses/7",
   "type": "CourseOffering",
   "courseNumber": "CPS 435",

--- a/v1p2/caliperEntityCourseSection.json
+++ b/v1p2/caliperEntityCourseSection.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/terms/201601/courses/7/sections/1",
   "type": "CourseSection",
   "academicSession": "Fall 2016",

--- a/v1p2/caliperEntityDigitalResource.json
+++ b/v1p2/caliperEntityDigitalResource.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/terms/201601/courses/7/sections/1/resources/1/syllabus.pdf",
   "type": "DigitalResource",
   "name": "Course Syllabus",

--- a/v1p2/caliperEntityDigitalResourceCollection.json
+++ b/v1p2/caliperEntityDigitalResourceCollection.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/terms/201601/courses/7/sections/1/resources/2",
   "type": "DigitalResourceCollection",
   "name": "Video Collection",

--- a/v1p2/caliperEntityDocument.json
+++ b/v1p2/caliperEntityDocument.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/etexts/201.epub",
   "type": "Document",
   "name": "IMS Caliper Implementation Guide",

--- a/v1p2/caliperEntityFillinBlankResponse.json
+++ b/v1p2/caliperEntityFillinBlankResponse.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/terms/201601/courses/7/sections/1/assess/1/items/1/users/554433/responses/1",
   "type": "FillinBlankResponse",
   "attempt": {

--- a/v1p2/caliperEntityForum.json
+++ b/v1p2/caliperEntityForum.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/terms/201601/courses/7/sections/1/forums/1",
   "type": "Forum",
   "name": "Caliper Forum",

--- a/v1p2/caliperEntityFrame.json
+++ b/v1p2/caliperEntityFrame.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/etexts/201?index=2502",
   "type": "Frame",
   "dateCreated": "2016-08-01T06:00:00.000Z",

--- a/v1p2/caliperEntityGroup.json
+++ b/v1p2/caliperEntityGroup.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/terms/201601/courses/7/sections/1/groups/2",
   "type": "Group",
   "name": "Discussion Group 2",

--- a/v1p2/caliperEntityHighlightAnnotation.json
+++ b/v1p2/caliperEntityHighlightAnnotation.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/users/554433/etexts/201/highlights/20",
   "type": "HighlightAnnotation",
   "annotator": {

--- a/v1p2/caliperEntityImageObject.json
+++ b/v1p2/caliperEntityImageObject.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/images/caliper_lti.jpg",
   "type": "ImageObject",
   "name": "IMS Caliper/LTI Integration Work Flow",

--- a/v1p2/caliperEntityLearningObjective.json
+++ b/v1p2/caliperEntityLearningObjective.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/terms/201601/courses/7/sections/1/assign/2",
   "type": "AssignableDigitalResource",
   "name": "Caliper Profile Design",

--- a/v1p2/caliperEntityLtiSession.json
+++ b/v1p2/caliperEntityLtiSession.json
@@ -1,28 +1,76 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/lti/sessions/b533eb02823f31024e6b7f53436c42fb99b31241",
   "type": "LtiSession",
-  "user": {
-    "id": "https://example.edu/users/554433",
-    "type": "Person"
-  },
-  "messageParameters": {
-    "lti_message_type": "basic-lti-launch-request",
-    "lti_version": "LTI-1p0",
-    "context_id": "https://example.edu/terms/201801/courses/7/sections/1",
-    "context_type": "urn:lti:context-type:ims/lis/CourseSection",
-    "context_label": "CPS 435-01",
-    "context_title": "CPS 435 Learning Analytics, Section 01",
-    "resource_link_id": "6b37a950-42c9-4117-8f4f-03e6e5c88d24",
-    "roles": [ "urn:lti:role:ims/lis/Learner" ],
-    "tool_consumer_instance_guid": "SomeLMS.example.edu",
-    "tool_consumer_instance_description": "Sample University (SomeLMS)",
-    "user_id": "0ae836b9-7fc9-4060-006f-27b2066ac545",
-    "custom_xstart": "2016-08-21T01:00:00Z",
-    "custom_caliper_profile_url": "https://example.edu/lti/tc/cps",
-    "custom_caliper_session_id": "1c519ff7-3dfa-4764-be48-d2fb35a2925a",
-    "ext_com_somelms_example_course_section_instructor": "https://example.edu/faculty/1234"
+    "user": {
+      "id": "https://example.edu/users/554433",
+      "type": "Person"
   },
   "dateCreated": "2018-11-15T10:15:00.000Z",
-  "startedAtTime": "2018-11-15T10:15:00.000Z"
+  "startedAtTime": "2018-11-15T10:15:00.000Z",
+  "messageParameters": {
+     "iss": "https://example.edu",
+     "sub": "https://example.edu/users/554433",
+     "aud": ["https://example.com/lti/tool"],
+     "exp": 1510185728,
+     "iat": 1510185228,
+     "azp": "962fa4d8-bcbf-49a0-94b2-2de05ad274af",
+     "nonce": "fc5fdc6d-5dd6-47f4-b2c9-5d1216e9b771",
+     "name": "Ms Jane Marie Doe",
+     "given_name": "Jane",
+     "family_name": "Doe",
+     "middle_name": "Marie",
+     "picture": "https://example.edu/jane.jpg",
+     "email": "jane@example.edu",
+     "locale": "en-US",
+     "https://purl.imsglobal.org/spec/lti/claim/deployment_id": "07940580-b309-415e-a37c-914d387c1150",
+     "https://purl.imsglobal.org/spec/lti/claim/message_type": "LtiResourceLinkRequest",
+     "https://purl.imsglobal.org/spec/lti/claim/version": "1.3.0",
+     "https://purl.imsglobal.org/spec/lti/claim/roles": [
+        "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student",
+        "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner",
+        "http://purl.imsglobal.org/vocab/lis/v2/membership#Mentor"
+     ],
+     "https://purl.imsglobal.org/spec/lti/claim/role_scope_mentor": [
+        "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator"
+     ],
+     "https://purl.imsglobal.org/spec/lti/claim/context": {
+        "id": "https://example.edu/terms/201801/courses/7/sections/1",
+        "label": "CPS 435-01",
+        "title": "CPS 435 Learning Analytics, Section 01",
+        "type": ["http://purl.imsglobal.org/vocab/lis/v2/course#CourseSection"]
+     },
+     "https://purl.imsglobal.org/spec/lti/claim/resource_link": {
+        "id": "200d101f-2c14-434a-a0f3-57c2a42369fd",
+        "description": "Assignment to introduce who you are",
+        "title": "Introduction Assignment"
+     },
+     "https://purl.imsglobal.org/spec/lti/claim/tool_platform": {
+        "guid": "https://example.edu",
+        "contact_email": "support@example.edu",
+        "description": "An Example Tool Platform",
+        "name": "Example Tool Platform",
+        "url": "https://example.edu",
+        "product_family_code": "ExamplePlatformVendor-Product",
+        "version": "1.0"
+     },
+     "https://purl.imsglobal.org/spec/lti/claim/launch_presentation": {
+        "document_target": "iframe",
+        "height": 320,
+        "width": 240,
+        "return_url": "https://example.edu/terms/201801/courses/7/sections/1/pages/1"
+     },
+     "https://purl.imsglobal.org/spec/lti/claim/custom": {
+        "xstart": "2017-04-21T01:00:00Z",
+        "request_url": "https://tool.com/link/123"
+     },
+     "https://purl.imsglobal.org/spec/lti/claim/lis": {
+        "person_sourcedid": "example.edu:71ee7e42-f6d2-414a-80db-b69ac2defd4",
+        "course_offering_sourcedid": "example.edu:SI182-F16",
+        "course_section_sourcedid": "example.edu:SI182-001-F16"
+     },
+     "http://www.ExamplePlatformVendor.com/session": {
+        "id": "89023sj890dju080"
+     }
+  }
 }

--- a/v1p2/caliperEntityMediaLocation.json
+++ b/v1p2/caliperEntityMediaLocation.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/videos/1225",
   "type": "MediaLocation",
   "currentTime": "PT30M54S",

--- a/v1p2/caliperEntityMediaObject.json
+++ b/v1p2/caliperEntityMediaObject.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/media/54321",
   "type": "MediaObject",
   "dateCreated": "2016-08-01T06:00:00.000Z",

--- a/v1p2/caliperEntityMembership.json
+++ b/v1p2/caliperEntityMembership.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/terms/201601/courses/7/sections/1/rosters/1/members/554433",
   "type": "Membership",
   "member": {

--- a/v1p2/caliperEntityMessage.json
+++ b/v1p2/caliperEntityMessage.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/terms/201601/courses/7/sections/1/forums/2/topics/1/messages/3",
   "type": "Message",
   "creators": [

--- a/v1p2/caliperEntityMultipleChoiceResponse.json
+++ b/v1p2/caliperEntityMultipleChoiceResponse.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/terms/201601/courses/7/sections/1/assess/1/items/2/users/554433/responses/1",
   "type": "MultipleChoiceResponse",
   "attempt": {

--- a/v1p2/caliperEntityMultipleResponseResponse.json
+++ b/v1p2/caliperEntityMultipleResponseResponse.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/terms/201601/courses/7/sections/1/assess/1/items/3/users/554433/responses/1",
   "type": "MultipleResponseResponse",
   "attempt": {

--- a/v1p2/caliperEntityOrganization.json
+++ b/v1p2/caliperEntityOrganization.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/colleges/1/depts/1",
   "type": "Organization",
   "name": "Computer Science Department",

--- a/v1p2/caliperEntityPage.json
+++ b/v1p2/caliperEntityPage.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.com/#/texts/imscaliperimplguide/cfi/6/10!/4/2/2/2@0:0",
   "type": "Page",
   "name": "Page 5",

--- a/v1p2/caliperEntityPerson.json
+++ b/v1p2/caliperEntityPerson.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/users/554433",
   "type": "Person",
   "dateCreated": "2016-08-01T06:00:00.000Z",

--- a/v1p2/caliperEntityResponseExtended.json
+++ b/v1p2/caliperEntityResponseExtended.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/terms/201601/courses/7/sections/1/assess/1/items/6/users/554433/responses/1",
   "type": "Response",
   "attempt": {

--- a/v1p2/caliperEntityResult.json
+++ b/v1p2/caliperEntityResult.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/terms/201601/courses/7/sections/1/assess/1/users/554433/attempts/1/results/1",
   "type": "Result",
   "attempt": {

--- a/v1p2/caliperEntityScore.json
+++ b/v1p2/caliperEntityScore.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/terms/201601/courses/7/sections/1/assess/1/users/554433/attempts/1/scores/1",
   "type": "Score",
   "attempt": {

--- a/v1p2/caliperEntitySelectTextResponse.json
+++ b/v1p2/caliperEntitySelectTextResponse.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/terms/201601/courses/7/sections/1/assess/1/items/4/users/554433/responses/1",
   "type": "SelectTextResponse",
   "attempt": {

--- a/v1p2/caliperEntitySession.json
+++ b/v1p2/caliperEntitySession.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/sessions/1f6442a482de72ea6ad134943812bff564a76259",
   "type": "Session",
   "user": {

--- a/v1p2/caliperEntitySharedAnnotation.json
+++ b/v1p2/caliperEntitySharedAnnotation.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/users/554433/etexts/201/shares/1",
   "type": "SharedAnnotation",
   "annotator": {

--- a/v1p2/caliperEntitySoftwareApplication.json
+++ b/v1p2/caliperEntitySoftwareApplication.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/autograder",
   "type": "SoftwareApplication",
   "name": "Auto Grader",

--- a/v1p2/caliperEntityTagAnnotation.json
+++ b/v1p2/caliperEntityTagAnnotation.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.com/users/554433/texts/imscaliperimplguide/tags/3",
   "type": "TagAnnotation",
   "annotator": {

--- a/v1p2/caliperEntityThread.json
+++ b/v1p2/caliperEntityThread.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/terms/201601/courses/7/sections/1/forums/1/topics/1",
   "type": "Thread",
   "name": "Caliper Information Model",

--- a/v1p2/caliperEntityTrueFalseResponse.json
+++ b/v1p2/caliperEntityTrueFalseResponse.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/terms/201601/courses/7/sections/1/assess/1/items/5/users/554433/responses/1",
   "type": "TrueFalseResponse",
   "attempt": {

--- a/v1p2/caliperEntityVideoObject.json
+++ b/v1p2/caliperEntityVideoObject.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/videos/1225",
   "type": "VideoObject",
   "mediaType": "video/ogg",

--- a/v1p2/caliperEntityWebPage.json
+++ b/v1p2/caliperEntityWebPage.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/terms/201601/courses/7/sections/1/pages/index.html",
   "type": "WebPage",
   "name": "CPS 435-01 Landing Page",

--- a/v1p2/caliperEnvelopeEntityBatch.json
+++ b/v1p2/caliperEnvelopeEntityBatch.json
@@ -1,17 +1,17 @@
 {
   "sensor": "https://example.edu/sensors/1",
   "sendTime": "2016-11-15T11:05:01.000Z",
-  "dataVersion":  "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "dataVersion":  "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "data": [
     {
-      "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+      "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
       "id": "https://example.edu/users/554433",
       "type": "Person",
       "dateCreated": "2016-08-01T06:00:00.000Z",
       "dateModified": "2016-09-02T11:30:00.000Z"
     },
     {
-      "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+      "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
       "id": "https://example.edu/etexts/201.epub",
       "type": "Document",
       "name": "IMS Caliper Implementation Guide",
@@ -29,7 +29,7 @@
       "version": "1.1"
     },
     {
-      "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+      "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
       "id": "https://example.edu/terms/201601/courses/7/sections/1/resources/2",
       "type": "DigitalResourceCollection",
       "name": "Video Collection",

--- a/v1p2/caliperEnvelopeEntitySingle.json
+++ b/v1p2/caliperEnvelopeEntitySingle.json
@@ -1,10 +1,10 @@
 {
   "sensor": "https://example.edu/sensors/1",
   "sendTime": "2016-11-15T11:05:01.000Z",
-  "dataVersion":  "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "dataVersion":  "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "data": [
     {
-      "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+      "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
       "id": "https://example.edu/terms/201601/courses/7/sections/1/resources/1/syllabus.pdf",
       "type": "DigitalResource",
       "name": "Course Syllabus",

--- a/v1p2/caliperEnvelopeEventBatch.json
+++ b/v1p2/caliperEnvelopeEventBatch.json
@@ -1,10 +1,10 @@
 {
   "sensor": "https://example.edu/sensors/1",
   "sendTime": "2016-11-15T11:05:01.000Z",
-  "dataVersion":  "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "dataVersion":  "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "data": [
     {
-      "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+      "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
       "id": "urn:uuid:72f66ce5-d2ec-44cc-bce5-41602e1015dc",
       "type": "NavigationEvent",
       "actor": {
@@ -52,7 +52,7 @@
       }
     },
     {
-      "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+      "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
       "id": "urn:uuid:c0afa013-64df-453f-b0a6-50f3efbe4cc0",
       "type": "AnnotationEvent",
       "actor": {
@@ -103,7 +103,7 @@
       }
     },
     {
-      "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+      "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
       "type": "ViewEvent",
       "id": "urn:uuid:94bad4bd-a7b1-4c3e-ade4-2253efe65172",
       "actor": {

--- a/v1p2/caliperEnvelopeEventContextArray.json
+++ b/v1p2/caliperEnvelopeEventContextArray.json
@@ -1,14 +1,14 @@
 {
   "sensor": "https://example.edu/sensors/1",
   "sendTime": "2017-11-15T10:15:01.000Z",
-  "dataVersion":  "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "dataVersion":  "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "data": [
     {
       "@context": [
         {
           "query": "http://schema.org/query"
         },
-        "https://purl.imsglobal.org/caliper/v1p2/context/Core"
+        "http://purl.imsglobal.org/ctx/caliper/v1p2"
       ],
       "id": "urn:uuid:3a648e68-f00d-4c08-aa59-8738e1884f2c",
       "type": "Event",

--- a/v1p2/caliperEnvelopeEventSingle.json
+++ b/v1p2/caliperEnvelopeEventSingle.json
@@ -1,10 +1,10 @@
 {
   "sensor": "https://example.edu/sensors/1",
   "sendTime": "2016-11-15T11:05:01.000Z",
-  "dataVersion":  "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "dataVersion":  "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "data": [
     {
-      "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+      "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
       "id": "urn:uuid:c51570e4-f8ed-4c18-bb3a-dfe51b2cc594",
       "type": "AssessmentEvent",
       "actor": {

--- a/v1p2/caliperEnvelopeEventThinned.json
+++ b/v1p2/caliperEnvelopeEventThinned.json
@@ -1,10 +1,10 @@
 {
   "sensor": "https://example.edu/sensors/1",
   "sendTime": "2017-11-15T10:15:01.000Z",
-  "dataVersion":  "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "dataVersion":  "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "data": [
       {
-        "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+        "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
         "id": "urn:uuid:71657137-8e6e-44f8-8499-e1c3df6810d2",
         "type": "NavigationEvent",
         "actor": "https://example.edu/users/554433",

--- a/v1p2/caliperEnvelopeMixedBatch.json
+++ b/v1p2/caliperEnvelopeMixedBatch.json
@@ -1,17 +1,17 @@
 {
   "sensor": "https://example.edu/sensors/1",
   "sendTime": "2016-11-15T11:05:01.000Z",
-  "dataVersion": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "dataVersion": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "data": [
     {
-      "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+      "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
       "id": "https://example.edu/users/554433",
       "type": "Person",
       "dateCreated": "2016-08-01T06:00:00.000Z",
       "dateModified": "2016-09-02T11:30:00.000Z"
     },
     {
-      "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+      "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
       "id": "https://example.edu/terms/201601/courses/7/sections/1/assess/1?ver=v1p0",
       "type": "Assessment",
       "name": "Quiz One",
@@ -42,13 +42,13 @@
       "version": "1.0"
     },
     {
-      "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+      "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
       "id": "https://example.edu",
       "type": "SoftwareApplication",
       "version": "v2"
     },
     {
-      "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+      "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
       "id": "https://example.edu/terms/201601/courses/7/sections/1",
       "type": "CourseSection",
       "academicSession": "Fall 2016",
@@ -63,7 +63,7 @@
       "dateCreated": "2016-08-01T06:00:00.000Z"
     },
     {
-      "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+      "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
       "id": "urn:uuid:c51570e4-f8ed-4c18-bb3a-dfe51b2cc594",
       "type": "AssessmentEvent",
       "actor": "https://example.edu/users/554433",
@@ -97,7 +97,7 @@
       }
     },
     {
-      "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+      "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
       "id": "urn:uuid:dad88464-0c20-4a19-a1ba-ddf2f9c3ff33",
       "type": "AssessmentEvent",
       "actor": "https://example.edu/users/554433",
@@ -133,7 +133,7 @@
       }
     },
     {
-      "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+      "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
       "id": "urn:uuid:a50ca17f-5971-47bb-8fca-4e6e6879001d",
       "type": "GradeEvent",
       "actor": {

--- a/v1p2/caliperEnvelopeToolUseEvent.json
+++ b/v1p2/caliperEnvelopeToolUseEvent.json
@@ -1,9 +1,9 @@
 {
   "sensor": "https://example.edu/sensors/1",
   "sendTime": "2016-11-15T11:05:01.000Z",
-  "dataVersion": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "dataVersion": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "data": [{
-    "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
     "id": "urn:uuid:7e10e4f3-a0d8-4430-95bd-783ffae4d916",
     "type": "ToolUseEvent",
     "actor": {

--- a/v1p2/caliperEventAnnotationBookmarked.json
+++ b/v1p2/caliperEventAnnotationBookmarked.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:d4618c23-d612-4709-8d9a-478d87808067",
   "type": "AnnotationEvent",
   "actor": {

--- a/v1p2/caliperEventAnnotationHighlighted.json
+++ b/v1p2/caliperEventAnnotationHighlighted.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:0067a052-9bb4-4b49-9d1a-87cd43da488a",
   "type": "AnnotationEvent",
   "actor": {

--- a/v1p2/caliperEventAnnotationShared.json
+++ b/v1p2/caliperEventAnnotationShared.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:3bdab9e6-11cd-4a0f-9d09-8e363994176b",
   "type": "AnnotationEvent",
   "actor": {

--- a/v1p2/caliperEventAnnotationTagged.json
+++ b/v1p2/caliperEventAnnotationTagged.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:b2009c63-2659-4cd2-b71e-6e03c498f02b",
   "type": "AnnotationEvent",
   "actor": {

--- a/v1p2/caliperEventAssessmentItemCompleted.json
+++ b/v1p2/caliperEventAssessmentItemCompleted.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:e5891791-3d27-4df1-a272-091806a43dfb",
   "type": "AssessmentItemEvent",
   "actor": {

--- a/v1p2/caliperEventAssessmentItemSkipped.json
+++ b/v1p2/caliperEventAssessmentItemSkipped.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:04e27704-73bf-4d3c-912c-1b2da40aef8f",
   "type": "AssessmentItemEvent",
   "actor": {

--- a/v1p2/caliperEventAssessmentItemStarted.json
+++ b/v1p2/caliperEventAssessmentItemStarted.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:1b557176-ba67-4624-b060-6bee670a3d8e",
   "type": "AssessmentItemEvent",
   "actor": {

--- a/v1p2/caliperEventAssessmentStarted.json
+++ b/v1p2/caliperEventAssessmentStarted.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:27734504-068d-4596-861c-2315be33a2a2",
   "type": "AssessmentEvent",
   "actor": {

--- a/v1p2/caliperEventAssessmentSubmitted.json
+++ b/v1p2/caliperEventAssessmentSubmitted.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:dad88464-0c20-4a19-a1ba-ddf2f9c3ff33",
   "type": "AssessmentEvent",
   "actor": {

--- a/v1p2/caliperEventAssignableActivated.json
+++ b/v1p2/caliperEventAssignableActivated.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:2635b9dd-0061-4059-ac61-2718ab366f75",
   "type": "AssignableEvent",
   "actor": {

--- a/v1p2/caliperEventBasicCreated.json
+++ b/v1p2/caliperEventBasicCreated.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:3a648e68-f00d-4c08-aa59-8738e1884f2c",
   "type": "Event",
   "actor": {

--- a/v1p2/caliperEventBasicModifiedExtended.json
+++ b/v1p2/caliperEventBasicModifiedExtended.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:5973dcd9-3126-4dcc-8fd8-8153a155361c",
   "type": "Event",
   "actor": {

--- a/v1p2/caliperEventForumSubscribed.json
+++ b/v1p2/caliperEventForumSubscribed.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:a2f41f9c-d57d-4400-b3fe-716b9026334e",
   "type": "ForumEvent",
   "actor": {

--- a/v1p2/caliperEventGradeGraded.json
+++ b/v1p2/caliperEventGradeGraded.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:a50ca17f-5971-47bb-8fca-4e6e6879001d",
   "type": "GradeEvent",
   "actor": {

--- a/v1p2/caliperEventGradeGradedItem.json
+++ b/v1p2/caliperEventGradeGradedItem.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:12c05c4e-253f-4073-9f29-5786f3ff3f36",
   "type": "GradeEvent",
   "actor": {

--- a/v1p2/caliperEventMediaPausedVideo.json
+++ b/v1p2/caliperEventMediaPausedVideo.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:956b4a02-8de0-4991-b8c5-b6eebb6b4cab",
   "type": "MediaEvent",
   "actor": {

--- a/v1p2/caliperEventMessagePosted.json
+++ b/v1p2/caliperEventMessagePosted.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:0d015a85-abf5-49ee-abb1-46dbd57fe64e",
   "type": "MessageEvent",
   "actor": {

--- a/v1p2/caliperEventMessageReplied.json
+++ b/v1p2/caliperEventMessageReplied.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:aed54386-a3fb-45ff-90f9-a35d3daaf031",
   "type": "MessageEvent",
   "actor": {

--- a/v1p2/caliperEventNavigationNavigatedTo.json
+++ b/v1p2/caliperEventNavigationNavigatedTo.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:ff9ec22a-fc59-4ae1-ae8d-2c9463ee2f8f",
   "type": "NavigationEvent",
   "actor": {

--- a/v1p2/caliperEventNavigationNavigatedToThinned.json
+++ b/v1p2/caliperEventNavigationNavigatedToThinned.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:71657137-8e6e-44f8-8499-e1c3df6810d2",
   "type": "NavigationEvent",
   "actor": "https://example.edu/users/554433",

--- a/v1p2/caliperEventSessionLoggedIn.json
+++ b/v1p2/caliperEventSessionLoggedIn.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:fcd495d0-3740-4298-9bec-1154571dc211",
   "type": "SessionEvent",
   "actor": {

--- a/v1p2/caliperEventSessionLoggedInExtended.json
+++ b/v1p2/caliperEventSessionLoggedInExtended.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:4ec2c31e-3ec0-4fe1-a017-b81561b075d7",
   "type": "SessionEvent",
   "actor": {

--- a/v1p2/caliperEventSessionLoggedOut.json
+++ b/v1p2/caliperEventSessionLoggedOut.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:a438f8ac-1da3-4d48-8c86-94a1b387e0f6",
   "type": "SessionEvent",
   "actor": {

--- a/v1p2/caliperEventSessionTimedOut.json
+++ b/v1p2/caliperEventSessionTimedOut.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:4e61cf6c-ffbe-45bc-893f-afe7ad4079dc",
   "type": "SessionEvent",
   "actor": {

--- a/v1p2/caliperEventThreadMarkedAsRead.json
+++ b/v1p2/caliperEventThreadMarkedAsRead.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:6b20c5ba-301c-4e56-85a0-2f3d9a94c249",
   "type": "ThreadEvent",
   "actor": {

--- a/v1p2/caliperEventToolLaunchLaunched.json
+++ b/v1p2/caliperEventToolLaunchLaunched.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/ToolLaunchProfile",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:a2e8b214-4d4a-4456-bb4c-099945749117",
   "type": "ToolLaunchEvent",
   "actor": {
@@ -47,24 +47,72 @@
       "id": "https://example.edu/users/554433",
       "type": "Person"
     },
-    "messageParameters": {
-      "lti_message_type": "basic-lti-launch-request",
-      "lti_version": "LTI-1p0",
-      "context_id": "https://example.edu/terms/201801/courses/7/sections/1",
-      "context_type": "urn:lti:context-type:ims/lis/CourseSection",
-      "context_label": "CPS 435-01",
-      "context_title": "CPS 435 Learning Analytics, Section 01",
-      "resource_link_id": "6b37a950-42c9-4117-8f4f-03e6e5c88d24",
-      "roles": [ "urn:lti:role:ims/lis/Learner" ],
-      "tool_consumer_instance_guid": "SomeLMS.example.edu",
-      "tool_consumer_instance_description": "Sample University (SomeLMS)",
-      "user_id": "0ae836b9-7fc9-4060-006f-27b2066ac545",
-      "custom_xstart": "2016-08-21T01:00:00Z",
-      "custom_caliper_profile_url": "https://example.edu/lti/tc/cps",
-      "custom_caliper_session_id": "1c519ff7-3dfa-4764-be48-d2fb35a2925a",
-      "ext_com_somelms_example_course_section_instructor": "https://example.edu/faculty/1234"
-    },
     "dateCreated": "2018-11-15T10:15:00.000Z",
-    "startedAtTime": "2018-11-15T10:15:00.000Z"
+    "startedAtTime": "2018-11-15T10:15:00.000Z",
+    "messageParameters": {
+       "iss": "https://example.edu",
+       "sub": "https://example.edu/users/554433",
+       "aud": ["https://example.com/lti/tool"],
+       "exp": 1510185728,
+       "iat": 1510185228,
+       "azp": "962fa4d8-bcbf-49a0-94b2-2de05ad274af",
+       "nonce": "fc5fdc6d-5dd6-47f4-b2c9-5d1216e9b771",
+       "name": "Ms Jane Marie Doe",
+       "given_name": "Jane",
+       "family_name": "Doe",
+       "middle_name": "Marie",
+       "picture": "https://example.edu/jane.jpg",
+       "email": "jane@example.edu",
+       "locale": "en-US",
+       "https://purl.imsglobal.org/spec/lti/claim/deployment_id": "07940580-b309-415e-a37c-914d387c1150",
+       "https://purl.imsglobal.org/spec/lti/claim/message_type": "LtiResourceLinkRequest",
+       "https://purl.imsglobal.org/spec/lti/claim/version": "1.3.0",
+       "https://purl.imsglobal.org/spec/lti/claim/roles": [
+          "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student",
+          "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner",
+          "http://purl.imsglobal.org/vocab/lis/v2/membership#Mentor"
+       ],
+       "https://purl.imsglobal.org/spec/lti/claim/role_scope_mentor": [
+          "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator"
+       ],
+       "https://purl.imsglobal.org/spec/lti/claim/context": {
+          "id": "https://example.edu/terms/201801/courses/7/sections/1",
+          "label": "CPS 435-01",
+          "title": "CPS 435 Learning Analytics, Section 01",
+          "type": ["http://purl.imsglobal.org/vocab/lis/v2/course#CourseSection"]
+       },
+       "https://purl.imsglobal.org/spec/lti/claim/resource_link": {
+          "id": "200d101f-2c14-434a-a0f3-57c2a42369fd",
+          "description": "Assignment to introduce who you are",
+          "title": "Introduction Assignment"
+       },
+       "https://purl.imsglobal.org/spec/lti/claim/tool_platform": {
+          "guid": "https://example.edu",
+          "contact_email": "support@example.edu",
+          "description": "An Example Tool Platform",
+          "name": "Example Tool Platform",
+          "url": "https://example.edu",
+          "product_family_code": "ExamplePlatformVendor-Product",
+          "version": "1.0"
+       },
+       "https://purl.imsglobal.org/spec/lti/claim/launch_presentation": {
+          "document_target": "iframe",
+          "height": 320,
+          "width": 240,
+          "return_url": "https://example.edu/terms/201801/courses/7/sections/1/pages/1"
+       },
+       "https://purl.imsglobal.org/spec/lti/claim/custom": {
+          "xstart": "2017-04-21T01:00:00Z",
+          "request_url": "https://tool.com/link/123"
+       },
+       "https://purl.imsglobal.org/spec/lti/claim/lis": {
+          "person_sourcedid": "example.edu:71ee7e42-f6d2-414a-80db-b69ac2defd4",
+          "course_offering_sourcedid": "example.edu:SI182-F16",
+          "course_section_sourcedid": "example.edu:SI182-001-F16"
+       },
+       "http://www.ExamplePlatformVendor.com/session": {
+          "id": "89023sj890dju080"
+       }
+    }
   }
 }

--- a/v1p2/caliperEventToolUseUsed.json
+++ b/v1p2/caliperEventToolUseUsed.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:7e10e4f3-a0d8-4430-95bd-783ffae4d916",
   "type": "ToolUseEvent",
   "actor": {

--- a/v1p2/caliperEventViewViewed.json
+++ b/v1p2/caliperEventViewViewed.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:cd088ca7-c044-405c-bb41-0b2a8506f907",
   "type": "ViewEvent",
   "actor": {

--- a/v1p2/caliperEventViewViewedExtended.json
+++ b/v1p2/caliperEventViewViewedExtended.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:3a9bd869-addc-48b1-80f6-a14b2ff591ed",
   "type": "ViewEvent",
   "actor": {

--- a/v1p2/caliperEventViewViewedFedSession.json
+++ b/v1p2/caliperEventViewViewedFedSession.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://purl.imsglobal.org/caliper/v1p2/context/Core",
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:4be6d29d-5728-44cd-8a8f-3d3f07e46b61",
   "type": "ViewEvent",
   "actor": {


### PR DESCRIPTION
This updates the fixtures in the v1p2 directory to be more true to the state of the v1p1 fixtures in `develop`, incorporating the updates to core that carry along with v1p1.

This is a foundational refactor as changes to "Cailper core" destined for 1.2 (i.e. "Anonymous entities", et al) should go into fixtures in v1p2 and _not_ v1p1's fixture directory.

