### PR TITLE
More general way of adding System Identifiers to Caliper things (cc204)

### DIFF
--- a/v1p2/caliperEntityCourseOffering.json
+++ b/v1p2/caliperEntityCourseOffering.json
@@ -5,7 +5,13 @@
   "courseNumber": "CPS 435",
   "academicSession": "Fall 2016",
   "name": "CPS 435 Learning Analytics",
-  "lisSourcedId": "example.edu:SI182-F16",
+  "otherIdentifiers": [
+    {
+      "type": "SystemIdentifier",
+      "identifier": "example.edu:SI182-F16",
+      "identifierType": "LisSourcedId"
+    }
+  ],
   "dateCreated": "2016-08-01T06:00:00.000Z",
   "dateModified": "2016-09-02T11:30:00.000Z"
 }

--- a/v1p2/caliperEntityCourseSection.json
+++ b/v1p2/caliperEntityCourseSection.json
@@ -5,7 +5,13 @@
   "academicSession": "Fall 2016",
   "courseNumber": "CPS 435-01",
   "name": "CPS 435 Learning Analytics, Section 01",
-  "lisSourcedId": "example.edu:SI182-001-F16",
+  "otherIdentifiers": [
+    {
+      "type": "SystemIdentifier",
+      "identifier": "example.edu:SI182-001-F16",
+      "identifierType": "LisSourcedId"
+    }
+  ],
   "category": "seminar",
   "subOrganizationOf": {
     "id": "https://example.edu/terms/201601/courses/7",

--- a/v1p2/caliperEntityPerson.json
+++ b/v1p2/caliperEntityPerson.json
@@ -2,7 +2,25 @@
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "https://example.edu/users/554433",
   "type": "Person",
+  "otherIdentifiers": [
+    {
+      "type": "SystemIdentifier",
+      "identifier": "example.edu:71ee7e42-f6d2-414a-80db-b69ac2defd4",
+      "identifierType": "LisSourcedId"
+    },
+    {
+      "type": "SystemIdentifier",
+      "identifier": "jane@example.edu",
+      "identifierType": "EmailAddress",
+      "source": "https://example.edu"
+    },
+    {
+      "type": "SystemIdentifier",
+      "identifier": "https://example.edu/users/554433",
+      "identifierType": "LtiUserId",
+      "source": "07940580-b309-415e-a37c-914d387c1150"
+    }
+  ],
   "dateCreated": "2016-08-01T06:00:00.000Z",
-  "dateModified": "2016-09-02T11:30:00.000Z",
-  "lisSourcedId": "example.edu:71ee7e42-f6d2-414a-80db-b69ac2defd4"
+  "dateModified": "2016-09-02T11:30:00.000Z"
 }

--- a/v1p2/caliperEntityPerson.json
+++ b/v1p2/caliperEntityPerson.json
@@ -10,15 +10,18 @@
     },
     {
       "type": "SystemIdentifier",
-      "identifier": "jane@example.edu",
-      "identifierType": "EmailAddress",
-      "source": "https://example.edu"
+      "identifier": "https://example.edu/users/554433",
+      "identifierType": "LtiUserId",
+      "source":  {
+        "id": "https://example.edu",
+        "type": "SoftwareApplication"
+      }
     },
     {
       "type": "SystemIdentifier",
-      "identifier": "https://example.edu/users/554433",
-      "identifierType": "LtiUserId",
-      "source": "07940580-b309-415e-a37c-914d387c1150"
+      "identifier": "jane@example.edu",
+      "identifierType": "EmailAddress",
+      "source": "https://example.edu"
     }
   ],
   "dateCreated": "2016-08-01T06:00:00.000Z",

--- a/v1p2/caliperEnvelopeEntityBatch.json
+++ b/v1p2/caliperEnvelopeEntityBatch.json
@@ -7,9 +7,27 @@
       "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
       "id": "https://example.edu/users/554433",
       "type": "Person",
+      "otherIdentifiers": [
+        {
+          "type": "SystemIdentifier",
+          "identifier": "example.edu:71ee7e42-f6d2-414a-80db-b69ac2defd4",
+          "identifierType": "LisSourcedId"
+        },
+        {
+          "type": "SystemIdentifier",
+          "identifier": "jane@example.edu",
+          "identifierType": "EmailAddress",
+          "source": "https://example.edu"
+        },
+        {
+          "type": "SystemIdentifier",
+          "identifier": "https://example.edu/users/554433",
+          "identifierType": "LtiUserId",
+          "source": "07940580-b309-415e-a37c-914d387c1150"
+        }
+      ],
       "dateCreated": "2016-08-01T06:00:00.000Z",
-      "dateModified": "2016-09-02T11:30:00.000Z",
-      "lisSourcedId": "example.edu:71ee7e42-f6d2-414a-80db-b69ac2defd4"
+      "dateModified": "2016-09-02T11:30:00.000Z"
     },
     {
       "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",

--- a/v1p2/caliperEnvelopeEntityBatch.json
+++ b/v1p2/caliperEnvelopeEntityBatch.json
@@ -15,15 +15,18 @@
         },
         {
           "type": "SystemIdentifier",
-          "identifier": "jane@example.edu",
-          "identifierType": "EmailAddress",
-          "source": "https://example.edu"
+          "identifier": "https://example.edu/users/554433",
+          "identifierType": "LtiUserId",
+          "source":  {
+            "id": "https://example.edu",
+            "type": "SoftwareApplication"
+          }
         },
         {
           "type": "SystemIdentifier",
-          "identifier": "https://example.edu/users/554433",
-          "identifierType": "LtiUserId",
-          "source": "07940580-b309-415e-a37c-914d387c1150"
+          "identifier": "jane@example.edu",
+          "identifierType": "EmailAddress",
+          "source": "https://example.edu"
         }
       ],
       "dateCreated": "2016-08-01T06:00:00.000Z",

--- a/v1p2/caliperEnvelopeMixedBatch.json
+++ b/v1p2/caliperEnvelopeMixedBatch.json
@@ -7,9 +7,27 @@
       "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
       "id": "https://example.edu/users/554433",
       "type": "Person",
+      "otherIdentifiers": [
+        {
+          "type": "SystemIdentifier",
+          "identifier": "example.edu:71ee7e42-f6d2-414a-80db-b69ac2defd4",
+          "identifierType": "LisSourcedId"
+        },
+        {
+          "type": "SystemIdentifier",
+          "identifier": "jane@example.edu",
+          "identifierType": "EmailAddress",
+          "source": "https://example.edu"
+        },
+        {
+          "type": "SystemIdentifier",
+          "identifier": "https://example.edu/users/554433",
+          "identifierType": "LtiUserId",
+          "source": "07940580-b309-415e-a37c-914d387c1150"
+        }
+      ],
       "dateCreated": "2016-08-01T06:00:00.000Z",
-      "dateModified": "2016-09-02T11:30:00.000Z",
-      "lisSourcedId": "example.edu:71ee7e42-f6d2-414a-80db-b69ac2defd4"
+      "dateModified": "2016-09-02T11:30:00.000Z"
     },
     {
       "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
@@ -55,7 +73,13 @@
       "academicSession": "Fall 2016",
       "courseNumber": "CPS 435-01",
       "name": "CPS 435 Learning Analytics, Section 01",
-      "lisSourcedId": "example.edu:SI182-001-F16",
+      "otherIdentifiers": [
+        {
+          "type": "SystemIdentifier",
+          "identifier": "example.edu:SI182-001-F16",
+          "identifierType": "LisSourcedId"
+        }
+      ],
       "category": "seminar",
       "subOrganizationOf": {
         "id": "https://example.edu/terms/201601/courses/7",

--- a/v1p2/caliperEnvelopeMixedBatch.json
+++ b/v1p2/caliperEnvelopeMixedBatch.json
@@ -15,15 +15,18 @@
         },
         {
           "type": "SystemIdentifier",
-          "identifier": "jane@example.edu",
-          "identifierType": "EmailAddress",
-          "source": "https://example.edu"
+          "identifier": "https://example.edu/users/554433",
+          "identifierType": "LtiUserId",
+          "source":  {
+            "id": "https://example.edu",
+            "type": "SoftwareApplication"
+          }
         },
         {
           "type": "SystemIdentifier",
-          "identifier": "https://example.edu/users/554433",
-          "identifierType": "LtiUserId",
-          "source": "07940580-b309-415e-a37c-914d387c1150"
+          "identifier": "jane@example.edu",
+          "identifierType": "EmailAddress",
+          "source": "https://example.edu"
         }
       ],
       "dateCreated": "2016-08-01T06:00:00.000Z",


### PR DESCRIPTION
This PR demos a more general way of including [system identifiers for things in Caliper (cc204)](https://github.com/IMSGlobal/caliper-central/issues/204); it tracks the three basic entities also changed in PR #217. Some things to note:

- we need a new Caliper "blank node" entity called `SystemIdentifier` (by "blank node", I mean it wouldn't have an `id` field, like `TextPositionSelector`)
- each Caliper Entity would have an added `otherIdentifiers` optional field, with possible value being a list of SystemIdentifiers
- SystemIdentifier thing would need: a required "identifier" field to hold the system ID value, a required "identifierType" field to hold the enumerated value of the type of identifier, and an optional "source" field to indicate who made the identifier (or who is the scope of authority over it)

For enumerated identifierTypes, we'd treat that as an enumerated Caliper vocab, just like we do with roles, etc. I think we probably need these entries in it to start:
- LisSourcedId
- OneRosterSourcedId
- SisSourcedId
- LtiContextId
- LtiDeploymentId
- LtiPlatformId
- LtiToolid
- LtiUserId
- EmailAddress
- AccountUserName
- SystemId
- Other

As @ojurosevic explained, a platform could know that an ID is a "SIS identifier", but not know if the upstream SIS used OneRoster or LIS to get the value into the platform; this leads me to think we need to have a generic SisSourcedId value as well as more specific ones for LIS and OR...

See also:
- [caliper contexts #93](https://github.com/IMSGlobal/caliper-contexts/pull/93)
