### PR TITLE
Add in some example use of extensions in SystemIdentifier fixtures

### DIFF
--- a/v1p2/caliperEntityPerson.json
+++ b/v1p2/caliperEntityPerson.json
@@ -22,6 +22,14 @@
       "identifier": "jane@example.edu",
       "identifierType": "EmailAddress",
       "source": "https://example.edu"
+    },
+    {
+      "type": "SystemIdentifier",
+      "identifier": "4567",
+      "identifierType": "SystemId",
+      "extensions": {
+        "com.examplePlatformVendor.identifier_type": "UserIdentifier"
+      }
     }
   ],
   "dateCreated": "2016-08-01T06:00:00.000Z",

--- a/v1p2/caliperEnvelopeEntityBatch.json
+++ b/v1p2/caliperEnvelopeEntityBatch.json
@@ -27,6 +27,14 @@
           "identifier": "jane@example.edu",
           "identifierType": "EmailAddress",
           "source": "https://example.edu"
+        },
+        {
+          "type": "SystemIdentifier",
+          "identifier": "4567",
+          "identifierType": "SystemId",
+          "extensions": {
+            "com.examplePlatformVendor.identifier_type": "UserIdentifier"
+          }
         }
       ],
       "dateCreated": "2016-08-01T06:00:00.000Z",

--- a/v1p2/caliperEnvelopeMixedBatch.json
+++ b/v1p2/caliperEnvelopeMixedBatch.json
@@ -27,6 +27,14 @@
           "identifier": "jane@example.edu",
           "identifierType": "EmailAddress",
           "source": "https://example.edu"
+        },
+        {
+          "type": "SystemIdentifier",
+          "identifier": "4567",
+          "identifierType": "SystemId",
+          "extensions": {
+            "com.examplePlatformVendor.identifier_type": "UserIdentifier"
+          }
         }
       ],
       "dateCreated": "2016-08-01T06:00:00.000Z",


### PR DESCRIPTION
Demonstrates use of the extensions field in the SystemIdentifier entity. Specifically shows how a sender could encode some meaningful data about what the `SystemId` actually represents.

See also
- [Caliper central issue 220](https://github.com/IMSGlobal/caliper-central/issues/220)
