### PR TITLE
Change sentDate to dateSent to correspond with standard date property naming convention

### DIFF
--- a/v1p1/caliperEntitySurveyInvitation.json
+++ b/v1p1/caliperEntitySurveyInvitation.json
@@ -3,7 +3,7 @@
   "id": "https://example.edu/surveys/100/invitations/users/112233",
   "type": "SurveyInvitation",
   "sentCount": 1,
-  "sentDate": "2018-11-15T10:05:00.000Z",
+  "dateSent": "2018-11-15T10:05:00.000Z",
   "rater": {
     "id": "https://example.edu/users/554433",
     "type": "Person"

--- a/v1p1/caliperEventSurveyInvitationAccepted.json
+++ b/v1p1/caliperEventSurveyInvitationAccepted.json
@@ -11,7 +11,7 @@
     "id": "https://example.edu/surveys/100/invitations/users/112233",
     "type": "SurveyInvitation",
     "sentCount": 1,
-    "sentDate": "2018-11-15T10:05:00.000Z",
+    "dateSent": "2018-11-15T10:05:00.000Z",
     "rater": {
       "id": "https://example.edu/users/112233",
       "type": "Person"

--- a/v1p1/caliperEventSurveyInvitationSent.json
+++ b/v1p1/caliperEventSurveyInvitationSent.json
@@ -11,7 +11,7 @@
     "id": "https://example.edu/surveys/100/invitations/users/554433",
     "type": "SurveyInvitation",
     "sentCount": 1,
-    "sentDate": "2018-11-15T10:05:00.000Z",
+    "dateSent": "2018-11-15T10:05:00.000Z",
     "rater": {
       "id": "https://example.edu/users/554433",
       "type": "Person"


### PR DESCRIPTION
This PR changes `SurveyInvitation.sentDate` to `dateSent` to correspond with the standard date property naming convention (e.g., `dateCreated`, `dateModified`, `datePublished`, etc.).