### PR TITLE
Remove SearchResponse.searchResults array property

### DIFF
--- a/v1p1/caliperEntitySearchResponse.json
+++ b/v1p1/caliperEntitySearchResponse.json
@@ -22,21 +22,5 @@
     "dateCreated": "2018-11-15T10:05:00.000Z"
   },
   "searchResultsItemCount": 3,
-  "searchResults": [{
-    "id": "https://example.edu/catalog/record/01234?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29",
-    "type": "Document",
-    "mediaType": "application/pdf"
-  },
-    {
-      "id": "https://example.edu/catalog/record/09876?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29",
-      "type": "VideoObject",
-      "mediaType": "video/ogg"
-    },
-    {
-      "id": "https://example.edu/catalog/record/05432?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29",
-      "type": "Document",
-      "mediaType": "application/epub+zip"
-    }
-  ],
   "dateCreated": "2018-11-15T10:05:00.000Z"
 }

--- a/v1p1/caliperEventSearchSearched.json
+++ b/v1p1/caliperEventSearchSearched.json
@@ -25,12 +25,7 @@
       "searchTerms": "IMS AND (Caliper OR Analytics)",
       "dateCreated": "2018-11-15T10:05:00.000Z"
     },
-    "searchResultsItemCount": 3,
-    "searchResults": [
-      "https://example.edu/catalog/record/01234?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29",
-      "https://example.edu/catalog/record/09876?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29",
-      "https://example.edu/catalog/record/05432?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29"
-    ]
+    "searchResultsItemCount": 3
   },
   "edApp": "https://example.edu",
   "group": {

--- a/v1p2/caliperEntitySearchResponse.json
+++ b/v1p2/caliperEntitySearchResponse.json
@@ -22,21 +22,5 @@
     "dateCreated": "2018-11-15T10:05:00.000Z"
   },
   "searchResultsItemCount": 3,
-  "searchResults": [{
-    "id": "https://example.edu/catalog/record/01234?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29",
-    "type": "Document",
-    "mediaType": "application/pdf"
-  },
-    {
-      "id": "https://example.edu/catalog/record/09876?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29",
-      "type": "VideoObject",
-      "mediaType": "video/ogg"
-    },
-    {
-      "id": "https://example.edu/catalog/record/05432?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29",
-      "type": "Document",
-      "mediaType": "application/epub+zip"
-    }
-  ],
   "dateCreated": "2018-11-15T10:05:00.000Z"
 }

--- a/v1p2/caliperEventNavigationNavigatedToThinned.json
+++ b/v1p2/caliperEventNavigationNavigatedToThinned.json
@@ -2,7 +2,7 @@
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
   "id": "urn:uuid:71657137-8e6e-44f8-8499-e1c3df6810d2",
   "type": "NavigationEvent",
-  "profile": "GeneralProfile",
+  "profile": "ReadingProfile",
   "actor": "https://example.edu/users/554433",
   "action": "NavigatedTo",
   "object": "https://example.edu/terms/201601/courses/7/sections/1/pages/2",

--- a/v1p2/caliperEventSearchSearched.json
+++ b/v1p2/caliperEventSearchSearched.json
@@ -25,12 +25,7 @@
       "searchTerms": "IMS AND (Caliper OR Analytics)",
       "dateCreated": "2018-11-15T10:05:00.000Z"
     },
-    "searchResultsItemCount": 3,
-    "searchResults": [
-      "https://example.edu/catalog/record/01234?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29",
-      "https://example.edu/catalog/record/09876?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29",
-      "https://example.edu/catalog/record/05432?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29"
-    ]
+    "searchResultsItemCount": 3
   },
   "edApp": "https://example.edu",
   "group": {

--- a/v1p2/commonErrorFixtures/caliperEventSearch-WrongAction.json
+++ b/v1p2/commonErrorFixtures/caliperEventSearch-WrongAction.json
@@ -25,12 +25,7 @@
       "searchTerms": "IMS AND (Caliper OR Analytics)",
       "dateCreated": "2018-11-15T10:05:00.000Z"
     },
-    "searchResultsItemCount": 3,
-    "searchResults": [
-      "https://example.edu/catalog/record/01234?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29",
-      "https://example.edu/catalog/record/09876?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29",
-      "https://example.edu/catalog/record/05432?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29"
-    ]
+    "searchResultsItemCount": 3
   },
   "edApp": "https://example.edu",
   "group": {


### PR DESCRIPTION
Per the agreement of the Caliper working group `SearchResponse.searchResults` property has been removed.  The spec, ontology, and contexts will also need to be touched.